### PR TITLE
Améliorer la mise en page durant la Markdownisation

### DIFF
--- a/marcheolex/markdown.py
+++ b/marcheolex/markdown.py
@@ -88,7 +88,6 @@ def creer_markdown_texte(texte, cache):
             contenu = contenu.replace("L-NL-NL-N", "L-NL-N")
         contenu = contenu.replace("L-N", "\n").strip()
         lignes = [l.strip() for l in contenu.split('\n')]
-        contenu = '\n'.join(lignes)
         
         # Markdownisation des listes numérotées
         for i in range(len(lignes)):

--- a/marcheolex/markdown.py
+++ b/marcheolex/markdown.py
@@ -78,15 +78,15 @@ def creer_markdown_texte(texte, cache):
 
         # Nettoyage de contenu (sauts de ligne)
         for br in contenu.find_all('br'):
-            br.replace_with("L-N")
+            br.replace_with('L-N')
         for p in contenu.find_all('p'):
-            p.replace_with(p.text.strip() + "L-NL-N")
+            p.replace_with(p.text.strip() + 'L-NL-N')
         contenu = contenu.text
-        contenu = contenu.replace("\n", "")
-        contenu = " ".join(contenu.split())
+        contenu = contenu.replace('\n', '')
+        contenu = ' '.join(contenu.split())
         for i in range(3):
-            contenu = contenu.replace("L-NL-NL-N", "L-NL-N")
-        contenu = contenu.replace("L-N", "\n").strip()
+            contenu = contenu.replace('L-NL-NL-N', 'L-NL-N')
+        contenu = contenu.replace('L-N', '\n').strip()
         lignes = [l.strip() for l in contenu.split('\n')]
         
         # Markdownisation des listes numérotées


### PR DESCRIPTION
- Sauts de ligne désormais pilotés uniquement par `<p>` et `<br>`, et
  non plus par des `\n` existants (ce qui est le cas dans
  legifrance il me semble) (présence de `\n` bidon dans certains
  XML)
- Des tags tels que `<p>`, `<br>`, etc automatiquement supprimés
  par `contenu.text`
- Assurer que l'on aura uniquement deux `\n` entre paragraphs, y
  compris pour les listes (plus lisible pour moi)