### PR TITLE
Fix #3

### DIFF
--- a/marcheolex/telecharger.py
+++ b/marcheolex/telecharger.py
@@ -35,6 +35,7 @@ from marcheolex.basededonnees import Livraison
 from marcheolex.utilitaires import telecharger
 from marcheolex.utilitaires import telecharger_cache
 from marcheolex.utilitaires import verif_taille
+from marcheolex.utilitaires import fusionner
 
 
 def telecharger_legifrance(url, fichier, cache_html, force=False):
@@ -236,7 +237,8 @@ def decompresser_base(base, date_fond, dates_majo, cache='cache'):
             os.path.join(cache, 'tar', base + '-fond-' + date + '.tar.gz'),
             '-C', os.path.join(rep, 'fond-' + date)])
         os.remove(os.path.join(rep, 'fond-' + date, 'erreur-tar'))
-        
+        shutil.move(os.path.join(rep, 'fond-' + date, 'legi'),
+                    os.path.join(cache, 'bases-xml', 'legi'))
     
     # Inscrire cette livraison dans la base de données
     try:
@@ -272,6 +274,8 @@ def decompresser_base(base, date_fond, dates_majo, cache='cache'):
             os.rename(os.path.join(rep, date),
                       os.path.join(rep, 'majo-' + date))
             os.remove(os.path.join(rep, 'majo-' + date, 'erreur-tar'))
+            fusionner(os.path.join(rep, 'majo-' + date, 'legi'),
+                      os.path.join(cache, 'bases-xml', 'legi'))
         
         # Inscrire cette livraison dans la base de données
         try:

--- a/marcheolex/utilitaires.py
+++ b/marcheolex/utilitaires.py
@@ -19,6 +19,7 @@ import os
 import re
 import subprocess
 import datetime
+import shutil
 from path import path
 
 MOIS = {
@@ -213,3 +214,17 @@ def verif_taille(taille, destination):
     else:
         return True
 
+
+def fusionner(root_src_dir, root_dst_dir):
+
+    for src_dir, dirs, files in os.walk(root_src_dir):
+        dst_dir = src_dir.replace(root_src_dir, root_dst_dir, 1)
+        if not os.path.exists(dst_dir):
+            os.makedirs(dst_dir)
+        for file_ in files:
+            src_file = os.path.join(src_dir, file_)
+            dst_file = os.path.join(dst_dir, file_)
+            if os.path.exists(dst_file):
+                os.remove(dst_file)
+            shutil.move(src_file, dst_dir)
+    shutil.rmtree(root_src_dir)


### PR DESCRIPTION
- extraire les TAR dans `cache/bases-xml/legi` en respectant
  la chronologie
- la fonction `fusionner` permet de fusionner `root_src_dir` dans
  `root_dst_dir`