### PR TITLE
Possible fix of #2

### DIFF
--- a/archeo-lex
+++ b/archeo-lex
@@ -31,7 +31,7 @@ from marcheolex.utilitaires import nop
 from marcheolex.utilitaires import obtenir_tous_textes
 
 # Manuel d’aide
-aide = ('''Usage: archeo-lex [--aide] [--debug] [--help] [--version] [--textes=<TEXTES>] [--base=<BASE>] [--livraison=<DATE>] [--initialisation] [--rechercher-xml] [--telecharger] [--ranger] [--lier] [--exporter] [--mise-a-jour | --nouveau] [--dialecte=<DIALECTE>] [--historique=<HISTORIQUE>] [--métadonnées] [--organisation=<TYPE>] [--bdd=<fichier>] [--cache=<dossier>] [--dossier=<dossier>]
+aide = ('''Usage: archeo-lex [--aide] [--debug] [--help] [--version] [--textes=<TEXTES>] [--base=<BASE>] [--livraison=<DATE>] [--initialisation] [--rechercher-xml] [--telecharger] [--ranger] [--lier] [--exporter] [--mise-a-jour | --nouveau] [--dialecte=<DIALECTE>] [--historique=<HISTORIQUE>] [--metadonnees=<METAS>] [--organisation=<TYPE>] [--bdd=<fichier>] [--cache=<dossier>] [--dossier=<dossier>]
 
 -t --textes=<TEXTES>       Types de textes à télécharger :
                              - "constitution-de-1958",
@@ -62,7 +62,10 @@ aide = ('''Usage: archeo-lex [--aide] [--debug] [--help] [--version] [--textes=<
    --historique=<HIST>     Fabrique l’historique avec le système :
                              - "git" (défaut)
                              - "fichiers" : plusieurs fichiers avec les dates [inactif]
-   --métadonnées           Afficher les métadonnées dans le texte
+   --metadonnees=<METAS>   Afficher les métadonnées dans le texte
+                           Les options META suivantes sont cumulables : "META1 META2 ..."
+                             - "lien" : liens internes des articles
+                             - "tdm" : table des matières [inactif]
    --organisation=<TYPE>   Organisation de l’arborescence des fichiers :
                              - "fichier-unique" (défaut) : unique fichier
                              - "repertoires-simple" : un répertoire par article, sans hiérarchie
@@ -115,7 +118,7 @@ def principal(arguments):
     data['base'] = arguments.get('--base') or 'LEGI'
     data['livraison'] = arguments.get('--livraison') or 'tout'
     data['format'] = {}
-    data['format']['dialecte'] = arguments.get('--format') or 'markdown'
+    data['format']['dialecte'] = arguments.get('--dialecte') or 'markdown'
     data['format']['historique'] = arguments.get('--historique') or 'git'
     data['format']['metadonnees'] = arguments.get('--metadonnees') or False
     data['format']['organisation'] = arguments.get('--organisation') or 'fichier-unique'

--- a/archeo-lex
+++ b/archeo-lex
@@ -120,7 +120,7 @@ def principal(arguments):
     data['format'] = {}
     data['format']['dialecte'] = arguments.get('--dialecte') or 'markdown'
     data['format']['historique'] = arguments.get('--historique') or 'git'
-    data['format']['metadonnees'] = arguments.get('--metadonnees') or False
+    data['format']['metadonnees'] = arguments.get('--metadonnees') or ''
     data['format']['organisation'] = arguments.get('--organisation') or 'fichier-unique'
     
     # Lecture des autres paramètres

--- a/marcheolex/exporter.py
+++ b/marcheolex/exporter.py
@@ -144,7 +144,8 @@ def creer_historique_texte(texte, format, dossier, cache):
         contenu = creer_sections(contenu, 1, None, versions_sections, articles, version_texte, cid, format, [], dossier, cache)
         
         # Ajouter des liens internes vers articles
-        contenu = ajouter_liens_internes(contenu)
+        if 'lien' in format['metadonnees']:
+            contenu = ajouter_liens_internes(contenu)
         
         # Enregistrement du fichier
         if format['organisation'] == 'fichier-unique':
@@ -241,6 +242,7 @@ def creer_articles_section(texte, niveau, version_section_parente, articles, ver
 def ajouter_liens_internes(contenu):
 
     # Corrections mineures pour les décrets *
+    # TODO afficher un message d'avertissement
     for l in ['R', 'D']:
         contenu = contenu.replace(l + '* ', l + '*')  # suppr. un espace en + dans l'art.
         contenu = contenu.replace(l + '. * ', l + '*. ')  # corrig. mauvais formattages
@@ -252,12 +254,13 @@ def ajouter_liens_internes(contenu):
     lignes = [l.strip() for l in contenu.split('\n')]
     for ligne in lignes:
         info = ligne.partition('# Article ')[2]
-        if info:
-            ind = re.search('\d', info).start()
+        num = re.search('\d', info)
+        if num:
+            ind = num.start()
             type_article = info[:ind]
             num_article = info[ind:]
             article = type_article + '. ' + num_article
-            contenu = contenu.replace(type_article + '.' + num_article, article)
+            contenu = contenu.replace(type_article + '.' + num_article, article)  # ajouter un espace
             type_article_lien = type_article.lower().replace('*', '')
             article_avec_lien = '[' + article.replace('*', r'\*') + ']' + \
                                 '(#article-' + type_article_lien + num_article + ')'

--- a/marcheolex/exporter.py
+++ b/marcheolex/exporter.py
@@ -217,8 +217,13 @@ def creer_articles_section(texte, niveau, version_section_parente, articles, ver
 
 def ajouter_liens_internes(contenu):
 
-    # Changement de style pour les décrets pris en conseil des ministres
-    contenu = contenu.replace('R. *', 'R*.')
+    # Corrections mineures pour les décrets *
+    for l in ['R', 'D']:
+        contenu = contenu.replace(l + '* ', l + '*')  # suppr. un espace en + dans l'art.
+        contenu = contenu.replace(l + '. * ', l + '*. ')  # corrig. mauvais formattages
+        contenu = contenu.replace(l + '. *', l + '*. ')
+        contenu = contenu.replace(l + '.* ', l + '*. ')
+        contenu = contenu.replace(l + '.*', l + '*. ')
 
     # Ajouter un lien interne vers l'article en question
     lignes = [l.strip() for l in contenu.split('\n')]
@@ -229,8 +234,10 @@ def ajouter_liens_internes(contenu):
             type_article = info[:ind]
             num_article = info[ind:]
             article = type_article + '. ' + num_article
-            article_avec_lien = '[' + article + ']' + \
-                                '(#article-' + type_article.lower() + num_article + ')'
+            contenu = contenu.replace(type_article + '.' + num_article, article)
+            type_article_lien = type_article.lower().replace('*', '')
+            article_avec_lien = '[' + article.replace('*', r'\*') + ']' + \
+                                '(#article-' + type_article_lien + num_article + ')'
             for symbole in [' ', ',', '.']:  # rechercher des mots exacts
                 contenu = contenu.replace(article + symbole, article_avec_lien + symbole)
     return contenu


### PR DESCRIPTION
Résultat : [http://www.litianyi.me/ceseda](http://www.litianyi.me/ceseda)

### Règles constatées du fichier brut Markdown généré :

- Si on a un article en section `# Article L/R/R*/D123-1` (le niveau n'est pas important ici)
- Alors dans le corps on l'utilise comme `L/R/R*/D. 123-1` (ajout d'un `.`)

Quelques mauvais formattages ponctuels ont été corrigés.

### Méthode

Cf. [https://kramdown.gettalong.org/converter/html.html](https://kramdown.gettalong.org/converter/html.html) et [http://stackoverflow.com/questions/6695439/how-to-link-to-a-named-anchor-in-multimarkdown](http://stackoverflow.com/questions/6695439/how-to-link-to-a-named-anchor-in-multimarkdown)

- `# Article L123-1` a pour lien interne `(#article-l123-1)`
- `## Article L123-1` a aussi pour lien interne `(#article-l123-1)`
- `# Article R*123-1` a pour lien interne `(#article-r123-1)`

### Perspective

Un (seul) bémol de l'implémentation présentée ici : parfois dans le corps on fait référence à un article disons `L. 123-1` **provenant d'un autre code**. Si par chance dans notre code en question on a aussi le même article `# Article L123-1`, ainsi **tous** les `L. 123-1` dans le corps vont être transformés en hyperliens vers l'article du code. Exemple : rechercher

```
article L. 821-1 du code de la sécurité sociale
```

dans [http://www.litianyi.me/ceseda](http://www.litianyi.me/ceseda).

La résolution de ce bug n'est pas triviale à ma première humble vue (vérifier si dans le corps l'article n'est pas suivi par ` du` ?).