### PR TITLE
Ajout de métadonnées en en-tête du fichier

### DIFF
--- a/marcheolex/exporterlegi.py
+++ b/marcheolex/exporterlegi.py
@@ -384,6 +384,15 @@ def creer_historique_texte(arg):
         if visas:
             contenu = visas_titre + visas + contenu
             fs.stockage.ecrire_ressource( 'VISAS', [(0, 'VISAS', 'Visas')], '', 'Visas', visas )
+        if format['metadonnees']:
+            date_fin_fr = 'aucune'
+            if fin != None and str(fin) != '2999-01-01':
+                date_fin_fr = '{} {} {}'.format(fin.day, MOIS2[int(fin.month)], fin.year)
+                if fin.day == 1:
+                    date_fin_fr = '1er {} {}'.format(MOIS2[int(fin.month)], fin.year)
+            metadonnees = '---\ntexte: {}\ndebut-vigueur: {}\nfin-vigueur: {}\nbase-legi: {}\n---\n\n'.format(nom_final.replace('_', ' '), date_debut_fr, date_fin_fr, date_base_legi_fr)
+            contenu = metadonnees + contenu
+            fs.stockage.ecrire_ressource( 'METADONNEES', [(0, 'METADONNEES', 'Metadonnées')], '', 'Métadonnées', metadonnees )
         if signataires:
             contenu += signataires_titre + signataires
             fs.stockage.ecrire_ressource( 'SIGNATAIRES', [(0, 'SIGNATAIRES', 'Signataires')], '', 'Signataires', signataires )


### PR DESCRIPTION
@revolunet Une proposition d’en-tête, tu me dis ce que tu en penses, il y a un exemple sur https://github.com/Seb35/code_des_instruments_monetaires_et_des_medailles (ce code est tout petit et donc pratique pour les tests).

Issue: #50 